### PR TITLE
Add remix-params-helper package

### DIFF
--- a/content/packages.yml
+++ b/content/packages.yml
@@ -15,3 +15,6 @@ remix-tailwind:
 remix-postcss:
   url: https://github.com/l-mbert/remix-postcss
   version: '>=1'
+remix-params-helper:
+  url: https://github.com/kiliman/remix-params-helper
+  version: '>=1'


### PR DESCRIPTION
This adds a helper package that makes it simple to use Zod with standard URLSearchParams and FormData which are typically used in Remix apps.